### PR TITLE
SonarCloud: CI-based analysis with coverage + badges

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,58 @@
+# SonarCloud analysis with test coverage (CI-based scanner).
+# Requires a GitHub org-level secret SONAR_TOKEN, and Automatic Analysis turned OFF for
+# project PFalkowski_LoggerLite (SonarCloud > Administration > Analysis Method).
+name: SonarCloud
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  sonar:
+    name: Build, test & analyze
+    runs-on: ubuntu-latest
+    # Skip PRs from forks — they can't access the SONAR_TOKEN secret.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK (required by the scanner)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Install scanner + coverage tools
+        run: |
+          dotnet tool install --global dotnet-sonarscanner
+          dotnet tool install --global dotnet-coverage
+
+      - name: Build, test (with coverage) & analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          dotnet-sonarscanner begin \
+            /k:"PFalkowski_LoggerLite" /o:"pfalkowski" \
+            /d:sonar.host.url="https://sonarcloud.io" \
+            /d:sonar.token="$SONAR_TOKEN" \
+            /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+          dotnet build --configuration Release
+          dotnet-coverage collect "dotnet test --configuration Release --no-build" -f xml -o coverage.xml
+          dotnet-sonarscanner end /d:sonar.token="$SONAR_TOKEN"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -52,6 +52,7 @@ jobs:
             /k:"PFalkowski_LoggerLite" /o:"pfalkowski" \
             /d:sonar.host.url="https://sonarcloud.io" \
             /d:sonar.token="$SONAR_TOKEN" \
+            /d:sonar.exclusions="**/*TestHarness/**" \
             /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
           dotnet build --configuration Release
           dotnet-coverage collect "dotnet test --configuration Release --no-build" -f xml -o coverage.xml

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/PFalkowski/LoggerLite/actions/workflows/ci.yml/badge.svg)](https://github.com/PFalkowski/LoggerLite/actions/workflows/ci.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=PFalkowski_LoggerLite&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=PFalkowski_LoggerLite)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=PFalkowski_LoggerLite&metric=coverage)](https://sonarcloud.io/summary/new_code?id=PFalkowski_LoggerLite)
 [![NuGet](https://img.shields.io/nuget/v/LoggerLite.svg)](https://www.nuget.org/packages/LoggerLite)
 [![Downloads](https://img.shields.io/nuget/dt/LoggerLite.svg)](https://www.nuget.org/packages/LoggerLite)
 [![License: MIT](https://img.shields.io/github/license/PFalkowski/LoggerLite.svg)](License.txt)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # LoggerLite
 
 [![CI](https://github.com/PFalkowski/LoggerLite/actions/workflows/ci.yml/badge.svg)](https://github.com/PFalkowski/LoggerLite/actions/workflows/ci.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=PFalkowski_LoggerLite&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=PFalkowski_LoggerLite)
 [![NuGet](https://img.shields.io/nuget/v/LoggerLite.svg)](https://www.nuget.org/packages/LoggerLite)
 [![Downloads](https://img.shields.io/nuget/dt/LoggerLite.svg)](https://www.nuget.org/packages/LoggerLite)
 [![License: MIT](https://img.shields.io/github/license/PFalkowski/LoggerLite.svg)](License.txt)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![NuGet](https://img.shields.io/nuget/v/LoggerLite.svg)](https://www.nuget.org/packages/LoggerLite)
 [![Downloads](https://img.shields.io/nuget/dt/LoggerLite.svg)](https://www.nuget.org/packages/LoggerLite)
 [![License: MIT](https://img.shields.io/github/license/PFalkowski/LoggerLite.svg)](License.txt)
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/piotrfalkowski)
 
 Lightweight, dependency-free logging for .NET — a thin, easy-to-read wrapper around `Console`,
 file streaming, `XDocument` and friends, behind a single `ILoggerLite` interface. Targets


### PR DESCRIPTION
Wires up SonarCloud **CI-based analysis with test coverage** for LoggerLite (the reference implementation for the refresh-nuget-repo skill's new default).

- **`.github/workflows/sonar.yml`** — `dotnet-sonarscanner` + `dotnet-coverage` on push/PR; reports coverage via `sonar.cs.vscoveragexml.reportsPaths`. Project `PFalkowski_LoggerLite`, org `pfalkowski`. Demo harness projects excluded so the metric reflects the library.
- **README badges**: SonarCloud quality-gate + coverage, plus a Buy Me a Coffee badge.

### Required one-time setup before/at merge (not in the repo)
1. **Org secret `SONAR_TOKEN`** — a SonarCloud *Global Analysis Token*, added as a GitHub **organization** secret (visible to all repos).
2. **Turn Automatic Analysis OFF** for the `PFalkowski_LoggerLite` project (Administration → Analysis Method) — CI-based and Automatic are mutually exclusive.

Until both are done, the first `sonar.yml` run will fail (missing token / autoscan conflict). After that, the badges populate on the next push to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)