### PR TITLE
test: cover untested branches to clear SonarCloud new-code coverage gate

### DIFF
--- a/LoggerLite.xTest/ActiveDebouncerTests.cs
+++ b/LoggerLite.xTest/ActiveDebouncerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Threading;
 using Xunit;
 
 namespace LoggerLite.xTest
@@ -50,6 +51,30 @@ namespace LoggerLite.xTest
             {
                 Assert.True(counter > 0);
             }
+        }
+
+        [Fact]
+        public void DisposeStopsStartedTimer()
+        {
+            using var callbackStarted = new ManualResetEventSlim(false);
+            using var releaseCallback = new ManualResetEventSlim(false);
+            // Long period so the single due-time-0 tick is the only one in the test window.
+            var tested = new ActiveDebouncer { DebounceMilliseconds = 10000 };
+
+            tested.Debounce(() =>
+            {
+                callbackStarted.Set();
+                releaseCallback.Wait(TimeSpan.FromSeconds(5));
+            });
+
+            // Block until the debounced callback is actually running, so the timer is
+            // started when Dispose() runs - exercising the StopTimer + Dispose path.
+            Assert.True(callbackStarted.Wait(TimeSpan.FromSeconds(5)),
+                "debounced callback never started");
+
+            tested.Dispose();
+
+            releaseCallback.Set();
         }
     }
 }

--- a/LoggerLite.xTest/ActiveDebouncerTests.cs
+++ b/LoggerLite.xTest/ActiveDebouncerTests.cs
@@ -56,25 +56,27 @@ namespace LoggerLite.xTest
         [Fact]
         public void DisposeStopsStartedTimer()
         {
-            using var callbackStarted = new ManualResetEventSlim(false);
-            using var releaseCallback = new ManualResetEventSlim(false);
+            // Volatile flags (no IDisposable) so the background timer thread can never
+            // touch a synchronization primitive that this method has already disposed.
+            var callbackRunning = false;
+            var release = false;
             // Long period so the single due-time-0 tick is the only one in the test window.
             var tested = new ActiveDebouncer { DebounceMilliseconds = 10000 };
 
             tested.Debounce(() =>
             {
-                callbackStarted.Set();
-                releaseCallback.Wait(TimeSpan.FromSeconds(5));
+                Volatile.Write(ref callbackRunning, true);
+                SpinWait.SpinUntil(() => Volatile.Read(ref release), TimeSpan.FromSeconds(5));
             });
 
             // Block until the debounced callback is actually running, so the timer is
-            // started when Dispose() runs - exercising the StopTimer + Dispose path.
-            Assert.True(callbackStarted.Wait(TimeSpan.FromSeconds(5)),
+            // still started when Dispose() runs - exercising the StopTimer + Dispose path.
+            Assert.True(SpinWait.SpinUntil(() => Volatile.Read(ref callbackRunning), TimeSpan.FromSeconds(5)),
                 "debounced callback never started");
 
             tested.Dispose();
 
-            releaseCallback.Set();
+            Volatile.Write(ref release, true);
         }
     }
 }

--- a/LoggerLite.xTest/AggregatedLoggerTests.cs
+++ b/LoggerLite.xTest/AggregatedLoggerTests.cs
@@ -195,5 +195,36 @@ namespace LoggerLite.xTest
             tested.LogWarning("test");
             mockLogger1.VerifyAll();
         }
+        [Fact]
+        public void AggregatedLoggerLogSuccessTest()
+        {
+            var mockLogger1 = new Mock<ILoggerLite>(MockBehavior.Strict);
+            var mockLogger2 = new Mock<ILoggerLite>(MockBehavior.Strict);
+            mockLogger1.Setup(l => l.LogSuccess(It.IsAny<string>()));
+            mockLogger2.Setup(l => l.LogSuccess(It.IsAny<string>()));
+            var tested = new AggregateLogger(new List<ILoggerLite> { mockLogger1.Object, mockLogger2.Object });
+
+            tested.LogSuccess("done");
+
+            mockLogger1.Verify(l => l.LogSuccess("done"), Times.Once);
+            mockLogger2.Verify(l => l.LogSuccess("done"), Times.Once);
+        }
+        [Fact]
+        public void LogThrowsAggregateExceptionCollectingChildFailures()
+        {
+            var failing = new Mock<ILoggerLite>();
+            failing.Setup(l => l.LogError(It.IsAny<string>()))
+                .Throws(new InvalidOperationException("child failed"));
+            var working = new Mock<ILoggerLite>();
+            var tested = new AggregateLogger(failing.Object, working.Object);
+
+            var aggregate = Assert.Throws<AggregateException>(
+                () => tested.Log("oops", MessageSeverity.Error));
+
+            Assert.Single(aggregate.InnerExceptions);
+            Assert.IsType<InvalidOperationException>(aggregate.InnerExceptions[0]);
+            // A sibling logger is still invoked even though an earlier one threw.
+            working.Verify(l => l.LogError("oops"), Times.Once);
+        }
     }
 }

--- a/LoggerLite.xTest/ConsoleLoggerTest.cs
+++ b/LoggerLite.xTest/ConsoleLoggerTest.cs
@@ -19,5 +19,19 @@ namespace LoggerLite.xTest
             Assert.Equal(3, tested.Successes);
             Assert.Equal(0, tested.Failures);
         }
+
+        [Fact]
+        public void LogSuccessUsesSuccessSeverityAndCountsSuccess()
+        {
+            // Exercises the MessageSeverity.Success branch (sets SuccessColor) which the
+            // other severities don't reach.
+            var tested = new ConsoleLogger();
+
+            tested.LogSuccess("operation completed");
+
+            Assert.Equal(1, tested.Requests);
+            Assert.Equal(1, tested.Successes);
+            Assert.Equal(0, tested.Failures);
+        }
     }
 }

--- a/LoggerLite.xTest/FileLoggerBaseTest.cs
+++ b/LoggerLite.xTest/FileLoggerBaseTest.cs
@@ -204,6 +204,16 @@ namespace LoggerLite.xTest
             Assert.True(tested1.PathToLog.EndsWith(".log"), $"{tested1.PathToLog} does not end with \".log\"");
         }
 
+        [Fact]
+        public void FileNameWithoutExtensionGetsDefaultExtension()
+        {
+            var tested = new FileLoggerBase("logfilewithoutextension");
+
+            Assert.Contains("logfilewithoutextension", tested.PathToLog);
+            Assert.True(tested.PathToLog.EndsWith(".log"),
+                $"{tested.PathToLog} does not end with \".log\"");
+        }
+
         // TODO: Write possible multithreaded scenarios
 
         //private static void AssertFileFormedWell(string myPath)

--- a/LoggerLite.xTest/HtmlLoggerTest.cs
+++ b/LoggerLite.xTest/HtmlLoggerTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Xml.Linq;
 using Xunit;
 
@@ -86,6 +87,29 @@ namespace LoggerLite.xTest
             Assert.Contains(error, actual);
             Assert.Contains(info, actual);
             Assert.Contains(warning, actual);
+        }
+
+        [Fact]
+        public void HtmlLoggerLoadsStylesheetFromFileInfoAndSaves()
+        {
+            var stylesheetPath = Path.Combine(Path.GetTempPath(), $"loggerlite_{Guid.NewGuid():N}.xslt");
+            var outputPath = Path.Combine(Path.GetTempPath(), $"loggerlite_{Guid.NewGuid():N}.html");
+            File.WriteAllText(stylesheetPath, Xslt);
+            try
+            {
+                const string info = "loaded from file";
+                var tested = new HtmlLogger(new FileInfo(stylesheetPath));
+
+                tested.LogInfo(info);
+                tested.Save(new FileInfo(outputPath));
+
+                Assert.Contains(info, File.ReadAllText(outputPath));
+            }
+            finally
+            {
+                File.Delete(stylesheetPath);
+                File.Delete(outputPath);
+            }
         }
     }
 }

--- a/LoggerLite.xTest/LoggerBaseTest.cs
+++ b/LoggerLite.xTest/LoggerBaseTest.cs
@@ -27,6 +27,26 @@ namespace LoggerLite.xTest
             {
             }
         }
+        private class RecordingLogger : LoggerBase
+        {
+            public string LastMessage { get; private set; }
+
+            public MessageSeverity LastSeverity { get; private set; }
+
+            public override bool FlushAuto => true;
+
+            public override bool IsThreadSafe => true;
+
+            public override void Log(string message, MessageSeverity severity)
+            {
+                LastMessage = message;
+                LastSeverity = severity;
+            }
+
+            public string CallTrimExcess(string input) => TrimExcess(input);
+
+            public void SetMaxSingleMessageLength(int value) => MaxSingleMessageLength = value;
+        }
         [Fact]
         public void ExceptionWhileLogging()
         {
@@ -135,6 +155,73 @@ namespace LoggerLite.xTest
             Assert.Equal(2, tested.Requests);
             Assert.Equal(2, tested.Successes);
             Assert.Equal(0, tested.Failures);
+        }
+
+        [Fact]
+        public void LogSuccessCountsFailureWhenLogThrows()
+        {
+            var tested = new LoggerBaseThrowingExceptionInLog();
+
+            tested.LogSuccess("done");
+
+            Assert.Equal(1, tested.Requests);
+            Assert.Equal(1, tested.Failures);
+            Assert.Equal(0, tested.Successes);
+        }
+
+        [Fact]
+        public void LogErrorWithExceptionCountsFailureWhenLogThrows()
+        {
+            var tested = new LoggerBaseThrowingExceptionInLog();
+
+            tested.LogError(new InvalidOperationException("kaboom"));
+
+            Assert.Equal(1, tested.Requests);
+            Assert.Equal(1, tested.Failures);
+            Assert.Equal(0, tested.Successes);
+        }
+
+        [Fact]
+        public void LogErrorWithDescriptionAppendsColonBeforeDescription()
+        {
+            var tested = new RecordingLogger();
+
+            tested.LogError(new Exception("Disk failure"), "while writing log");
+
+            Assert.Equal("Disk failure: while writing log", tested.LastMessage);
+            Assert.Equal(MessageSeverity.Error, tested.LastSeverity);
+        }
+
+        [Fact]
+        public void LogErrorWithDescriptionDoesNotAddASecondColon()
+        {
+            var tested = new RecordingLogger();
+
+            tested.LogError(new Exception("Disk failure:"), "while writing log");
+
+            Assert.Equal("Disk failure: while writing log", tested.LastMessage);
+        }
+
+        [Fact]
+        public void TrimExcessReturnsInputUnchangedWhenNullOrEmpty()
+        {
+            var tested = new RecordingLogger();
+
+            Assert.Null(tested.CallTrimExcess(null));
+            Assert.Equal(string.Empty, tested.CallTrimExcess(string.Empty));
+        }
+
+        [Fact]
+        public void TrimExcessTruncatesMessagesLongerThanMax()
+        {
+            var tested = new RecordingLogger();
+            tested.SetMaxSingleMessageLength(20);
+            var input = new string('x', 50);
+
+            var actual = tested.CallTrimExcess(input);
+
+            Assert.Equal(20, actual.Length);
+            Assert.EndsWith(LoggerBase.TruncateInfo, actual);
         }
     }
 }


### PR DESCRIPTION
## Why

The SonarCloud **Quality Gate** on `master` is failing on a single condition: **new-code coverage 79.8% < 80%** (24 uncovered new lines out of 119). Everything else (reliability, security, maintainability, duplication, hotspots) is green. This is not a CI/re-run issue — the gate is deterministic on the code, so it needs tests for the uncovered paths.

## What

12 behavioral tests covering the genuinely-untested branches (no coverage padding, no production code changed):

| Class | Uncovered behavior now tested |
|---|---|
| `LoggerBase` | `LogSuccess` / `LogError(Exception)` count a **failure** when `Log` throws; `LogError(exception, description)` colon formatting (both branches); `TrimExcess` null/empty + truncation paths |
| `AggregateLogger` | `LogSuccess` fan-out to all loggers; throws `AggregateException` collecting child failures while still invoking siblings |
| `ActiveDebouncer` | `Dispose()` while the timer is started (deterministic, event-gated — no sleeps) |
| `ConsoleLogger` | `Success` severity branch |
| `FileLoggerBase` | filename without extension gets default `.log` |
| `HtmlLogger` | `FileInfo` stylesheet constructor (loads XSLT from disk) |

## Verification

- `dotnet test` → **92 passed / 0 failed** (was 80).
- Collected coverage with `dotnet-coverage` (same tool as CI) and confirmed **all 24 previously-uncovered lines are now covered** → new-code coverage ≈ 100%, clearing the 80% gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)